### PR TITLE
[dav] COREUS-2 Fix: handle ezvcard client list values

### DIFF
--- a/src/main/java/net/fortuna/ical4j/vcard/property/Uid.java
+++ b/src/main/java/net/fortuna/ical4j/vcard/property/Uid.java
@@ -71,7 +71,13 @@ public final class Uid extends Property {
      */
     public Uid(List<Parameter> params, String value) throws URISyntaxException {
         super(Id.UID, params);
-        this.uri = new URI(value);
+        try {
+            this.uri = new URI(value);
+        } catch (URISyntaxException e) {
+            if (value.contains("\\,")) {
+                this.uri = new URI(value.substring(value.lastIndexOf("\\,") + 2));
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Le client ezvcard nous envoie les UIDs en forme de 
```<container>\,<UID>```
qui ne peut pas être parsé en URI.